### PR TITLE
Add policy tags support

### DIFF
--- a/intelliment.yml
+++ b/intelliment.yml
@@ -3,30 +3,75 @@
   gather_facts: false
   connection: local
 
-  tasks:
-    - name: Create visibility requirements on Intelliment
-      intelliment: 
-        scenario: 15
-        policies:
-          - source: "0.0.0.0/0"
-            destination: "eu-banking-app"
-            action: "allow"
-            services: "tcp/80"
-          - source: "i-034ee5dbfd85f6837"
-            destination: "0.0.0.0/0"
-            action: "allow"
-            services: "tcp/75"
-          - source: "0.0.0.0/0"
-            destination: "subnet-79972720"
-            action: "allow"
-            services: "tcp/60-100"
-          - source: "subnet-79972720"
-            destination: "0.0.0.0/0"
-            action: "allow"
-            services: "tcp/200-300"          
-          - source: "B_intranet"
-            destination: "backend-1"
-            action: "allow"
-            services: "tcp/443"
-      register: result
+  vars:
+    scenario: 64
+    objects:
+      web_servers:
+        - app-ws
+        - app-ws2
+      all_servers:
+        - app-database
+        - app-ws
+        - app-ws2
+        - puppet-dns
+    services:
+      mysql: "tcp/3306"
+      https: "tcp/443"
+      ssh:   "tcp/22"
+      dns:   "udp/53"
 
+  tasks:
+    - name: HTTPS from Users to web_servers
+      intelliment: 
+        scenario: "{{ scenario }}"
+        policies:
+          - source: "Users"
+            destination: "{{ item }}"
+            action: "allow"
+            services: "{{ services.https }}"
+      register: result
+      with_items: "{{ objects.web_servers }}"
+      
+    - name: HTTPS from HQ_DMZ to web_servers
+      intelliment: 
+        scenario: "{{ scenario }}"
+        policies:
+          - source: "HQ_DMZ"
+            destination: "{{ item }}"
+            action: "allow"
+            services: "{{ services.https }}"
+      register: result
+      with_items: "{{ objects.web_servers }}"
+
+    - name: MySQL from web_servers to app-database
+      intelliment: 
+        scenario: "{{ scenario }}"
+        policies:
+          - source: "{{ item }}"
+            destination: "app-database"
+            action: "allow"
+            services: "{{ services.mysql }}"
+      register: result
+      with_items: "{{ objects.web_servers }}"
+
+    - name: DNS from all servers to puppet-dns
+      intelliment: 
+        scenario: "{{ scenario }}"
+        policies:
+          - source: "{{ item }}"
+            destination: "puppet-dns"
+            action: "allow"
+            services: "{{ services.dns }}"
+      register: result
+      with_items: "{{ objects.all_servers }}"
+
+    - name: SSH from Admins to all servers
+      intelliment: 
+        scenario: "{{ scenario }}"
+        policies:
+          - source: "Admins"
+            destination: "{{ item }}"
+            action: "allow"
+            services: "{{ services.ssh }}"
+      register: result
+      with_items: "{{ objects.all_servers }}"

--- a/intelliment.yml
+++ b/intelliment.yml
@@ -4,7 +4,7 @@
   connection: local
 
   vars:
-    scenario: 64
+    scenario: 2855
     objects:
       web_servers:
         - app-ws
@@ -29,6 +29,10 @@
             destination: "{{ item }}"
             action: "allow"
             services: "{{ services.https }}"
+            tags:
+              - "loc:london"
+              - "stage:prod"
+              - "func:web"
       register: result
       with_items: "{{ objects.web_servers }}"
       
@@ -40,6 +44,10 @@
             destination: "{{ item }}"
             action: "allow"
             services: "{{ services.https }}"
+            tags:
+              - "loc:london"
+              - "stage:prod"
+              - "func:web"
       register: result
       with_items: "{{ objects.web_servers }}"
 
@@ -51,6 +59,10 @@
             destination: "app-database"
             action: "allow"
             services: "{{ services.mysql }}"
+            tags:
+              - "loc:london"
+              - "stage:prod"
+              - "func:db"
       register: result
       with_items: "{{ objects.web_servers }}"
 
@@ -62,6 +74,10 @@
             destination: "puppet-dns"
             action: "allow"
             services: "{{ services.dns }}"
+            tags:
+              - "loc:london"
+              - "stage:prod"
+              - "func:dns"
       register: result
       with_items: "{{ objects.all_servers }}"
 
@@ -73,5 +89,9 @@
             destination: "{{ item }}"
             action: "allow"
             services: "{{ services.ssh }}"
+            tags:
+              - "loc:london"
+              - "stage:prod"
+              - "func:ssh"
       register: result
       with_items: "{{ objects.all_servers }}"

--- a/library/intelliment.py
+++ b/library/intelliment.py
@@ -61,7 +61,7 @@ def create_requirements(policies, scenario_id):
 				"type": "custom",
 				"services": resolve_services(policy)
 			}],
-			"tags" : ""
+			"tags" : policy["tags"] if "tags" in policy else []
 		}
 
 		policy_endpoints = resolve_endpoints(scenario_id, policy, internet)
@@ -69,8 +69,8 @@ def create_requirements(policies, scenario_id):
 		if is_aws_related(policy_endpoints):
 			create_aws_related_requirement(scenario_id, requirement, policy_endpoints)
 		else:
-			tag = policy_endpoints["source"] + "-" + policy_endpoints["destination"]
-			create_requirement(scenario_id, requirement, tag, policy_endpoints["source"], policy_endpoints["source_type"], policy_endpoints["destination"], policy_endpoints["destination_type"])
+			tags = ["ansible"]
+			create_requirement(scenario_id, requirement, tags, policy_endpoints["source"], policy_endpoints["source_type"], policy_endpoints["destination"], policy_endpoints["destination_type"])
 
 """ 
  Creates AWS related requirement solving its security group or network ACL related 
@@ -95,9 +95,9 @@ def create_aws_related_requirement(scenario_id, requirement, policy_endpoints):
 """ 
  Creates a requirement via Intelliment API 
 """
-def create_requirement(scenario_id, requirement, tag, source, source_type, destination, destination_type):
+def create_requirement(scenario_id, requirement, tags, source, source_type, destination, destination_type):
 	
-	requirement["tags"] = [tag]
+	requirement["tags"] += tags
 	requirement["source"] = {
 		"type": source_type,
 		"value": source


### PR DESCRIPTION
Now policies can have an array of tags, like this:

        policies:
          - source: "Users"
            destination: "{{ item }}"
            action: "allow"
            services: "{{ services.https }}"
            tags:
              - "loc:london"
              - "stage:prod"
              - "func:web"

Additionally an "ansible" tag will be added to each policy created.